### PR TITLE
update prefix in render_field #1

### DIFF
--- a/acf-reusable_field_group-v5.php
+++ b/acf-reusable_field_group-v5.php
@@ -159,6 +159,7 @@ class acf_field_reusable_field_group extends acf_field {
         $name_prefix = '';
 
         if (isset($field['parent'])) {
+            $field['prefix'] = str_replace('row-', '', $field['prefix']);
             preg_match_all('/\[(field_\w+)\](\[(\d+)\])?/', $field['prefix'], $parent_fields);
 
 


### PR DESCRIPTION
Repeater rows are prefixed with 'row-$i' in ACF 5.8 but are still saved as $i.